### PR TITLE
Add on-keydown listener to birch-typeahead version of standards picker.

### DIFF
--- a/birch-standards-picker.html
+++ b/birch-standards-picker.html
@@ -50,7 +50,8 @@ Example:
       on-birch-typeahead:input='_handleInput'
       on-birch-typeahead:cancel='_handleCancel'
       on-birch-typeahead:blur='_handleCancel'
-      on-birch-typeahead:selected='_handleSelect'>
+      on-birch-typeahead:selected='_handleSelect'
+      on-keydown="_handleKeydown">
       <template>
 
         <template is="dom-if" if="[[item.icon]]" restamp>


### PR DESCRIPTION
This is to catch key down events for scrolling with arrows and 'enter'. Catching 'enter' here prevents the parent form from submitting when a standard is selected.