### PR TITLE
bugfix: pass through formalDate so that we can save dates correctly

### DIFF
--- a/birch-standards-picker.html
+++ b/birch-standards-picker.html
@@ -650,6 +650,7 @@ The following custom properties and mixins are available for styling:
           standardText: option.value,
           earliestAstro: option.earliestAstro,
           latestAstro: option.latestAstro,
+          formalText: option.formalDate,
           type: option.type,
           yearRange: option.yearRange,
           sortKeyShort: option.sortKeyShort

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "birch-standards-picker",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "description": "A picker for the FamilySearch date/place standards",
   "main": [
     "birch-standards-picker.html",


### PR DESCRIPTION
See TW-743.

This change adds formalText to the `data` object. This will allow those who are saving dates to pass that same param back to the endpoints.