### PR TITLE
Improvements

### DIFF
--- a/birch-standards-picker.html
+++ b/birch-standards-picker.html
@@ -199,14 +199,13 @@ The following custom properties and mixins are available for styling:
           color: #333331;
           padding: 6px 10px 6px 25px;
         };
-
         --birch-typeahead-input-disabled: {
           background-color: #eee;
         };
-
         --birch-typeahead-paper-item: {
           @apply --birch-standards-picker-paper-item;
         };
+        --paper-item-body-two-line-min-height: 50px;
       }
       paper-item, paper-icon-item, paper-item-body {
         --paper-item: {
@@ -420,7 +419,9 @@ The following custom properties and mixins are available for styling:
         },
 
         /**
-         * The object containing the standards picker's current state
+         * The object containing the standards picker's current state.
+         * `customText` and `standardText` should never be identical.
+         * If they are, `customeText` will be deleted.
          *
          * @type {Object}
          */
@@ -492,6 +493,9 @@ The following custom properties and mixins are available for styling:
         this.$.optionsMenu.select(-1);
         this.$.typeahead.hideOptionsAndBlur(false);
         this._showNonStandardSelectedIndicator = false;
+        this._hideStandards = true;
+        this.hideStandardsMenu = true;
+        this.loading = false;
       },
 
       _resetArrays: function(){
@@ -506,6 +510,11 @@ The following custom properties and mixins are available for styling:
       },
 
       _handleDataChange: function(data) {
+        if(data.customText === data.standardText){
+          delete data.customText;
+          this._updateData(this._clone(data));
+          return this._handleDataChange(this.data);
+        }
         if(!this.searchTerm && (data.customText || data.standardText)){
           this.searchTerm = data.customText || data.standardText;
           if(!data.label){
@@ -740,7 +749,10 @@ The following custom properties and mixins are available for styling:
         this._setShowNonStandardSelectedIndicator(this.data, this.searchTerm, this._standardOptions);
       },
 
-      _openStandardSelector: function() {
+      _openStandardSelector: function(e) {
+        // Have to programmatically focus the button because firefox doesn't do it automatically
+        e.target.focus();
+
         if (this._standardOptions.length < 1) return;
         this._hideStandards = this._hideStandards ? false : true;
       },
@@ -851,7 +863,7 @@ The following custom properties and mixins are available for styling:
       },
 
       _hideStandardsContainer: function(data, standardType, i18n, hideStandardsMenu) {
-        if(! i18n || hideStandardsMenu) return true;
+        if(!i18n || hideStandardsMenu) return true;
         var standardType = standardType.toUpperCase();
         var noStandardText = i18n('NO_STANDARD_' + standardType + '_AVAILABLE');
         return !data.customText || data.label === noStandardText;

--- a/birch-standards-picker.html
+++ b/birch-standards-picker.html
@@ -493,7 +493,6 @@ The following custom properties and mixins are available for styling:
         this.$.typeahead.hideOptionsAndBlur(false);
         this._showNonStandardSelectedIndicator = false;
         this._hideStandards = true;
-        this.hideStandardsMenu = true;
         this.loading = false;
       },
 
@@ -732,7 +731,6 @@ The following custom properties and mixins are available for styling:
         this._updateData(e.detail.selection);
         this.$.optionsMenu.select(0);
         this._setStandardSelected(e.detail.selection);
-        if(!this.standardSelected) this.hideStandardsMenu = false;
         this._setShowNonStandardSelectedIndicator(this.data, this.searchTerm, this._standardOptions);
       },
 

--- a/birch-standards-picker.html
+++ b/birch-standards-picker.html
@@ -509,22 +509,24 @@ The following custom properties and mixins are available for styling:
       },
 
       _handleDataChange: function(data) {
-        // If customText matches standardText exactly,
-        // delete customText and run this function again.
-        if(data.customText === data.standardText){
-          delete data.customText;
-          this._updateData(this._clone(data));
-          return this._handleDataChange(this.data);
-        }
-
         if(!this.searchTerm && (data.customText || data.standardText)){
           this.searchTerm = data.customText || data.standardText;
+
           if(!data.label){
             var clonedData = this._clone(this.data);
             clonedData.label = clonedData.standardText || undefined;
             this._updateData(clonedData);
             this._handleDataChange(this.data);
           }
+
+          // If customText matches standardText exactly,
+          // delete customText and run this function again.
+          if(data.customText === data.standardText){
+            delete data.customText;
+            this._updateData(this._clone(data));
+            this._handleDataChange(this.data);
+          }
+
           var fakeEvent = {
             detail: {
               value: this.searchTerm

--- a/birch-standards-picker.html
+++ b/birch-standards-picker.html
@@ -732,6 +732,7 @@ The following custom properties and mixins are available for styling:
         this._updateData(e.detail.selection);
         this.$.optionsMenu.select(0);
         this._setStandardSelected(e.detail.selection);
+        if(!this.standardSelected) this.hideStandardsMenu = false;
         this._setShowNonStandardSelectedIndicator(this.data, this.searchTerm, this._standardOptions);
       },
 

--- a/birch-standards-picker.html
+++ b/birch-standards-picker.html
@@ -145,7 +145,6 @@ The following custom properties and mixins are available for styling:
         font-size: 14px;
         padding: 5px;
         border-radius: 5px;
-        max-width: 300px;
         overflow: hidden;
       }
       #button .standard-indicator {

--- a/birch-standards-picker.html
+++ b/birch-standards-picker.html
@@ -510,11 +510,13 @@ The following custom properties and mixins are available for styling:
       },
 
       _handleDataChange: function(data) {
+        // If customText matches standardText exactly, delete customText.
         if(data.customText === data.standardText){
           delete data.customText;
           this._updateData(this._clone(data));
           return this._handleDataChange(this.data);
         }
+
         if(!this.searchTerm && (data.customText || data.standardText)){
           this.searchTerm = data.customText || data.standardText;
           if(!data.label){

--- a/birch-standards-picker.html
+++ b/birch-standards-picker.html
@@ -527,6 +527,8 @@ The following custom properties and mixins are available for styling:
             this._handleDataChange(this.data);
           }
 
+          // Must trigger the input handler so that standards
+          // will get fetched even though the user has not typed.
           var fakeEvent = {
             detail: {
               value: this.searchTerm

--- a/birch-standards-picker.html
+++ b/birch-standards-picker.html
@@ -509,7 +509,8 @@ The following custom properties and mixins are available for styling:
       },
 
       _handleDataChange: function(data) {
-        // If customText matches standardText exactly, delete customText.
+        // If customText matches standardText exactly,
+        // delete customText and run this function again.
         if(data.customText === data.standardText){
           delete data.customText;
           this._updateData(this._clone(data));
@@ -751,7 +752,8 @@ The following custom properties and mixins are available for styling:
       },
 
       _openStandardSelector: function(e) {
-        // Have to programmatically focus the button because firefox doesn't do it automatically
+        // We have to programmatically focus the button on
+        // click because firefox doesn't do it automatically.
         e.target.focus();
 
         if (this._standardOptions.length < 1) return;


### PR DESCRIPTION
* Remove `max-width` from standards selector button
* Decrease typeahead option `min-height` from the default `72px` to `50px`
* Delete `customText` when `customText` and `standardText` are identical (update docs to reflect this behavior)
* Reset more properties in the `reset` function
* Programmatically focus the standards button on click because firefox doesn't do it automatically
* Fix a typo