### PR TITLE
A few handy updates from your friendly neighborhood Spiderman.

### DIFF
--- a/birch-standards-picker.html
+++ b/birch-standards-picker.html
@@ -727,7 +727,7 @@ The following custom properties and mixins are available for styling:
         if(e.model.item.label === this.i18n('NONE_OF_THE_ABOVE')){
           e.model.item.label = this.i18n('NO_STANDARD_SELECTED');
         }
-        var data = Object.assign({}, e.model.item, this.data, { customText: this.searchTerm });
+        var data = Object.assign({}, e.model.item, { customText: this.searchTerm });
         this._updateData(data);
         this._hideStandards = true;
       },

--- a/birch-standards-picker.html
+++ b/birch-standards-picker.html
@@ -510,6 +510,7 @@ The following custom properties and mixins are available for styling:
       },
 
       _handleDataChange: function(data) {
+        this._setStandardSelected(data);
         if(!this.searchTerm && (data.customText || data.standardText)){
           this.searchTerm = data.customText || data.standardText;
 
@@ -605,7 +606,7 @@ The following custom properties and mixins are available for styling:
           this.loading = false;
           return this.reset();
         }
-        this.standardSelected = false;
+        if(isProgramaticFetch !== true) this.standardSelected = false;
         if(!e.detail.value.trim()) return;
         this.loading = true;
         this._fetchData(e.detail.value, isProgramaticFetch);
@@ -740,7 +741,6 @@ The following custom properties and mixins are available for styling:
         this.loading = false;
         this._updateData(e.detail.selection);
         this.$.optionsMenu.select(0);
-        this._setStandardSelected(e.detail.selection);
         this._setShowNonStandardSelectedIndicator(this.data, this.searchTerm, this._standardOptions);
       },
 
@@ -906,7 +906,7 @@ The following custom properties and mixins are available for styling:
 
       // Track whether the current selection has custom text
       _setStandardSelected: function(selection) {
-        this.standardSelected = !selection.customText;
+        this.standardSelected = selection.standardText && !selection.customText;
       },
 
       _showStandardInputIcon: function(bool, standardSelected) {

--- a/birch-standards-picker.html
+++ b/birch-standards-picker.html
@@ -655,9 +655,17 @@ The following custom properties and mixins are available for styling:
         this._typeaheadOptions = this._setupTypeaheadOptions([].concat(options));
         if(isProgramaticFetch === true){
           this.$.typeahead.hideOptions();
+          if(!this.standardSelected && this.data.standardText){
+            this._selectStandardOptionByStandardizedText(this.data.standardText);
+          }
         }
 
         this._setShowNonStandardSelectedIndicator(this.data, this.searchTerm, this._standardOptions);
+      },
+
+      _selectStandardOptionByStandardizedText: function(text) {
+        const index = this._standardOptions.map(item => item.standardText).indexOf(text);
+        if(~index) this.$.optionsMenu.select(index);
       },
 
       _mapOptionsCB: function(option) {
@@ -719,8 +727,8 @@ The following custom properties and mixins are available for styling:
         if(e.model.item.label === this.i18n('NONE_OF_THE_ABOVE')){
           e.model.item.label = this.i18n('NO_STANDARD_SELECTED');
         }
-        e.model.item.customText = this.data.customText;
-        this._updateData(e.model.item);
+        var data = Object.assign({}, e.model.item, this.data, { customText: this.searchTerm });
+        this._updateData(data);
         this._hideStandards = true;
       },
 

--- a/birch-standards-picker.html
+++ b/birch-standards-picker.html
@@ -312,7 +312,8 @@ The following custom properties and mixins are available for styling:
           data-test="PickStandardBtn"
           on-focusout="_handleFocusout"
           on-tap="_openStandardSelector"
-          on-keydown="_handleKeydown">
+          on-keydown="_handleKeydown"
+          title$="[[_getStandardLabel(data)]]">
 
           <span class="standardIcon" hidden$="[[_hideStandardIcon(data.label, i18n)]]">
             <template is="dom-if" if="[[isDate]]">

--- a/birch-standards-picker.html
+++ b/birch-standards-picker.html
@@ -5,7 +5,7 @@
 <link rel="import" href="../paper-listbox/paper-listbox.html">
 <link rel="import" href="../oak-i18n-behavior/oak-i18n-behavior.html">
 <link rel="import" href="../fs-metrics/fs-metrics.html">
-<!-- object-assign-shim is only to support IE11, but it's tiny anyhow -->
+<!-- object-assign-shim is only to support IE11 and Android webview, but it's tiny anyhow -->
 <script src="../object-assign-shim/index.js"></script>
 
 <!--

--- a/birch-standards-picker.html
+++ b/birch-standards-picker.html
@@ -246,7 +246,7 @@ The following custom properties and mixins are available for styling:
       on-birch-typeahead:selected='_handleSelect'>
 
       <template slot="item-template">
-        <template is="dom-if" if="[[item.icon]]">
+        <template is="dom-if" if="[[item.icon]]" restamp>
           <paper-icon-item style="display: flex; align-items: center;" title$="[[item.label]]">
             <template is="dom-if" if="[[isDate]]">
               <svg slot="item-icon" item-icon id="Layer_1" data-name="Layer 1" width="14" height="16" viewBox="0 0 14 16"><path d="M1,15.9A.94.94,0,0,1,.1,15V3.6A1.5,1.5,0,0,1,1.6,2.1h.3V3A1.1,1.1,0,0,0,3,4.1h.1V.1H4a.9.9,0,0,1,.9.9V2.1h4V3A1.1,1.1,0,0,0,10,4.1h.1V.1H11a.9.9,0,0,1,.9.9V2.1h.5a1.5,1.5,0,0,1,1.5,1.5V15a.94.94,0,0,1-.94.94Zm.86-1.8H12.1V5.9H1.9Z" style="fill:#333331"/><rect width="14" height="16" style="fill:none"/><path d="M3.17,12.24l.59-.76a2.12,2.12,0,0,0,1.47.61c.65,0,1-.28,1-.68s-.33-.62-1.07-.62l-.66,0v-1h.66c.59,0,1-.18,1-.57s-.43-.63-1-.63a1.92,1.92,0,0,0-1.35.55l-.57-.71a2.63,2.63,0,0,1,2-.85c1.25,0,2,.56,2,1.45a1.31,1.31,0,0,1-1.17,1.22,1.34,1.34,0,0,1,1.25,1.28c0,.92-.82,1.57-2.1,1.57A2.67,2.67,0,0,1,3.17,12.24Z" style="fill:#333331"/><path d="M9.33,13V9.13l-.89.9-.65-.68L9.47,7.67h1V13Z" style="fill:#333331"/></svg>
@@ -263,7 +263,7 @@ The following custom properties and mixins are available for styling:
             </template>
           </paper-icon-item>
         </template>
-        <template is="dom-if" if="[[!item.icon]]">
+        <template is="dom-if" if="[[!item.icon]]" restamp>
           <paper-icon-item title$="[[item.label]]">
             <paper-item-body style="display: flex; flex-direction: column; justify-content: center; flex: 1; flex-basis: .000000001px;">
               <div class="standard-label" style="white-space:normal;color:#333331;">[[item.label]]</div>


### PR DESCRIPTION
* Highlight the selected standard option on load
* Adding a `title` attribute to the standard select button so there's a hover tooltip
* Fix a bug selecting the typeahead option under the one clicked
* Fix a bug causing the standard select to show even when a standard is selected
* Fix a bug preventing the standard icon within the input from appearing on load