### PR TITLE
make standards picker work inside of fs-dialog v5

### DIFF
--- a/birch-standards-picker.html
+++ b/birch-standards-picker.html
@@ -229,6 +229,7 @@ The following custom properties and mixins are available for styling:
     </style>
 
     <birch-typeahead
+      focusable-component
       id='typeahead'
       input-label="[[inputLabel]]"
       aria-input-label='[[inputLabel]]'
@@ -476,7 +477,7 @@ The following custom properties and mixins are available for styling:
           type: Boolean,
           value: false
         },
-        
+
         /**
          * Way to confirm if change has occurred
          */


### PR DESCRIPTION
We need this attribute so that fs-dialog will properly "loop" when tabbing through elements. 