### PR TITLE
Custom URL Enhancement

### DIFF
--- a/birch-standards-picker.html
+++ b/birch-standards-picker.html
@@ -286,25 +286,27 @@ The following custom properties and mixins are available for styling:
       </div>
     </birch-typeahead>
 
-    <div aria-live="polite" class="status-container">
-      <template is="dom-if" if="[[_showStandardSelectedIndicator(data, searchTerm)]]">
-        <div class="standard-indicator standard small" data-test-standard-indicator title="[[_getStandardizedIndicatorText(standardType, i18n)]]">
-          <small data-test="StandardIndicator">[[_getStandardizedIndicatorText(standardType, i18n)]]</small>
-        </div>
-      </template>
+    <template is="dom-if" if="[[_showStatusContainer(hideStatusContainer)]]">
+      <div aria-live="polite" class="status-container">
+        <template is="dom-if" if="[[_showStandardSelectedIndicator(data, searchTerm)]]">
+          <div class="standard-indicator standard small" data-test-standard-indicator title="[[_getStandardizedIndicatorText(standardType, i18n)]]">
+            <small data-test="StandardIndicator">[[_getStandardizedIndicatorText(standardType, i18n)]]</small>
+          </div>
+        </template>
 
-      <template is="dom-if" if="[[_showNonStandardSelectedIndicator]]">
-        <div class="standard-indicator non-standard small" data-test-nonStandard-indicator title="[[_getNonStandardizedIndicatorText(standardType, i18n)]]">
-          <small data-test="NonstandardIndicator">[[_getNonStandardizedIndicatorText(standardType, i18n)]]</small>
-        </div>
-      </template>
+        <template is="dom-if" if="[[_showNonStandardSelectedIndicator]]">
+          <div class="standard-indicator non-standard small" data-test-nonStandard-indicator title="[[_getNonStandardizedIndicatorText(standardType, i18n)]]">
+            <small data-test="NonstandardIndicator">[[_getNonStandardizedIndicatorText(standardType, i18n)]]</small>
+          </div>
+        </template>
 
-      <template is="dom-if" if="[[_isNonStandardSelected(data, i18n, 'true')]]">
-        <div class="standard-indicator non-standard small" data-test-nonStandard-indicator title="[[_getStandardLabel(data)]]">
-          <small data-test="NonstandardIndicator2">[[_getStandardLabel(data)]]</small>
-        </div>
-      </template>
-    </div>
+        <template is="dom-if" if="[[_isNonStandardSelected(data, i18n, 'true')]]">
+          <div class="standard-indicator non-standard small" data-test-nonStandard-indicator title="[[_getStandardLabel(data)]]">
+            <small data-test="NonstandardIndicator2">[[_getStandardLabel(data)]]</small>
+          </div>
+        </template>
+      </div>
+    </template>
 
     <div class="standard-container" hidden$='[[_hideStandardsContainer(data, standardType, i18n, hideStandardsMenu)]]'>
       <p>
@@ -933,11 +935,11 @@ The following custom properties and mixins are available for styling:
 
       // searchTerm is passed here simply to trigger this observer
       _showStandardSelectedIndicator: function(data, searchTerm) {
-        if (this.hideStatusContainer) {
-          return false;
-        }
-
         return data.standardText;
+      },
+
+      _showStatusContainer: function(hideStatusContainer) {
+        return !hideStatusContainer;
       },
 
       _setShowNonStandardSelectedIndicator: function(data, searchTerm, standardOptions) {

--- a/birch-standards-picker.html
+++ b/birch-standards-picker.html
@@ -688,7 +688,8 @@ The following custom properties and mixins are available for styling:
         }
         options = options.map(this._mapOptionsCB.bind(this));
         this._standardOptions = [].concat(options);
-        this._typeaheadOptions = this._setupTypeaheadOptions([].concat(options));
+        // Don't add anything to the response if customUrl is set
+        this._typeaheadOptions = this.customUrl ? options : this._setupTypeaheadOptions([].concat(options));
         if(isProgramaticFetch === true){
           this.$.typeahead.hideOptions();
           if(!this.standardSelected && this.data.standardText){

--- a/birch-standards-picker.html
+++ b/birch-standards-picker.html
@@ -475,6 +475,16 @@ The following custom properties and mixins are available for styling:
           value: ''
         },
 
+        /**
+         * Specifies whether or not to hide the standards status container
+         *
+         * @type {Boolean}
+         */
+        hideStatusContainer: {
+          type: Boolean,
+          value: false
+        },
+
         _typeaheadOptions: {
           type: Array,
           value: function() { return []; }
@@ -923,6 +933,10 @@ The following custom properties and mixins are available for styling:
 
       // searchTerm is passed here simply to trigger this observer
       _showStandardSelectedIndicator: function(data, searchTerm) {
+        if (this.hideStatusContainer) {
+          return false;
+        }
+
         return data.standardText;
       },
 


### PR DESCRIPTION
Stopped the component from adding options to the API response if the `customUrl` property is being used.

Also added a property to optionally hide the status container (the part that shows "Standardized Date", etc...).