### PR TITLE
Add input and input-focus mixins

### DIFF
--- a/birch-standards-picker.html
+++ b/birch-standards-picker.html
@@ -199,10 +199,16 @@ The following custom properties and mixins are available for styling:
           box-sizing: border-box;
           color: #333331;
           padding: 6px 10px 6px 25px;
+          @apply --birch-standards-picker-input;
         };
+
         --birch-typeahead-input-disabled: {
           background-color: #eee;
         };
+
+        --birch-typeahead-input-focus: {
+          @apply --birch-standards-picker-input-focus;
+        }
 
         --birch-typeahead-paper-item-body-children: {
           font-weight: bold;

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "birch-standards-picker",
-  "version": "2.14.0",
+  "version": "2.14.1",
   "description": "A picker for the FamilySearch date/place standards",
   "main": [
     "birch-standards-picker.html",


### PR DESCRIPTION
Add the following CSS mixins in order to style the input field:
* `--birch-standards-picker-input`
* `--birch-standards-picker-input-focus`