### PR TITLE
Fixing "out of sync" input label when switching between date/place

### DIFF
--- a/birch-standards-picker.html
+++ b/birch-standards-picker.html
@@ -749,7 +749,7 @@ The following custom properties and mixins are available for styling:
       _updateLabels: function (i18n, standardType) {
         if (!i18n) return;
         this.standardsDropdownLabel = this.i18n('STANDARD_' + this.standardType.toUpperCase() + '_LABEL');
-        this.inputLabel = this.inputLabel || this.i18n('EVENT_' + this.standardType.toUpperCase() + '_LABEL');
+        this.inputLabel = this.i18n('EVENT_' + this.standardType.toUpperCase() + '_LABEL');
       },
 
       _getPlaceholder: function (type, i18n, disabled) {

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "birch-standards-picker",
-  "version": "2.14.7",
+  "version": "2.14.8",
   "description": "A picker for the FamilySearch date/place standards",
   "main": [
     "birch-standards-picker.html",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "birch-standards-picker",
-  "version": "2.14.7",
+  "version": "2.14.8",
   "description": "Polymer-based web component for viewing the fan chart pedigree view.",
   "directories": {
     "test": "test"


### PR DESCRIPTION
- Result of error: Once `inputLabel` has been set, it will use the same `inputLabel` even if the `standardType` has been changed

> If applied, this commit will **_Fix input label not updating with a change to `standardType`_**.

Fixes: JIRA PS-3587