### PR TITLE
make it so that you can set a custom inputLabel again while still switching it if no custom label is set to the default for the standard type

### DIFF
--- a/birch-standards-picker.html
+++ b/birch-standards-picker.html
@@ -297,8 +297,8 @@ The following custom properties and mixins are available for styling:
       class$="[[_setItemClass(isDate, showThinDate)]]"
       focusable-component
       id='typeahead'
-      input-label="[[inputLabel]]"
-      aria-input-label='[[inputLabel]]'
+      input-label="[[_inputLabel]]"
+      aria-input-label='[[_inputLabel]]'
       highlight-first-item
       follow-tabindex-after-tab-select
       loading="[[loading]]"
@@ -749,7 +749,7 @@ The following custom properties and mixins are available for styling:
       _updateLabels: function (i18n, standardType) {
         if (!i18n) return;
         this.standardsDropdownLabel = this.i18n('STANDARD_' + this.standardType.toUpperCase() + '_LABEL');
-        this.inputLabel = this.i18n('EVENT_' + this.standardType.toUpperCase() + '_LABEL');
+        this._inputLabel = this.inputLabel || this.i18n('EVENT_' + this.standardType.toUpperCase() + '_LABEL');
       },
 
       _getPlaceholder: function (type, i18n, disabled) {

--- a/birch-standards-picker.html
+++ b/birch-standards-picker.html
@@ -628,7 +628,7 @@ The following custom properties and mixins are available for styling:
       },
 
       observers: [
-        '_updateLabels(i18n, standardType)',
+        '_updateLabels(i18n, standardType, inputLabel)',
         '_setIsDateOrPlace(standardType)'
       ],
 
@@ -746,7 +746,7 @@ The following custom properties and mixins are available for styling:
         if (_isDate && _showThinDate) return 'max-height: 50px; font-weight: 100;';
       },
 
-      _updateLabels: function (i18n, standardType) {
+      _updateLabels: function (i18n, standardType, inputLabel) {
         if (!i18n) return;
         this.standardsDropdownLabel = this.i18n('STANDARD_' + this.standardType.toUpperCase() + '_LABEL');
         this._inputLabel = this.inputLabel || this.i18n('EVENT_' + this.standardType.toUpperCase() + '_LABEL');

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "birch-standards-picker",
-  "version": "2.14.8",
+  "version": "2.14.9",
   "description": "A picker for the FamilySearch date/place standards",
   "main": [
     "birch-standards-picker.html",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "birch-standards-picker",
-  "version": "2.14.8",
+  "version": "2.14.9",
   "description": "Polymer-based web component for viewing the fan chart pedigree view.",
   "directories": {
     "test": "test"


### PR DESCRIPTION
I introduced a bug when merging this PR: https://github.com/fs-webdev/birch-standards-picker/pull/46 where you can no longer specify a custom input label. This now uses an internal variable to set the inputLabel on the birch-typeahead so that if a user sets `inputLabel`, we always use that, but we default back to the correct one on type change even if the user hasn't set one or unsets the custom field.
