### PR TITLE
[TW-2280] Update Travis CI Configurations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ branches:
     - master
 # Caching of bower_components & node_modules disabled, due to an increase in delayed breakages
 cache:
+  npm: false
   directories: null
 dist: trusty
 language: node_js
@@ -22,7 +23,7 @@ notifications:
       - "\tin %{duration} for %{author}'s commit:"
       - "\t\"%{commit_subject}\""
     rooms:
-      - 'ldschurch:S4NvL7BI3BFGOMfoiSCfARk5#treeweb-gold-builds'
+      - 'familysearch:S4NvL7BI3BFGOMfoiSCfARk5#treeweb-gold-builds'
     on_pull_requests: false
     on_success: always
     on_failure: change


### PR DESCRIPTION
This PR partially resolves [TW-2280](https://almtools.ldschurch.org/fhjira/browse/TW-2280).

- Update Slack integration because `ldschurch.slack.com` is now `familysearch.slack.com`
- Explicitly tell Travis not to cache NPM because as of July 2019 [they are cached by default](https://docs.travis-ci.com/user/caching/#npm-cache).


