### PR TITLE
Add api look up lang override

### DIFF
--- a/birch-standards-picker.html
+++ b/birch-standards-picker.html
@@ -627,10 +627,10 @@ The following custom properties and mixins are available for styling:
         },
 
         /**
-         * Override the language of the data lookup in the date and place api. 
+         * Override the language of the data lookup in the date and place api.
          * If set to 'es' and the browser lang is set to 'en', the data entered would be Spanish.
          * This is useful when we have records that have a different language than the
-         * browser language 
+         * browser language
          */
         langOverride: {
           type: String
@@ -781,7 +781,7 @@ The following custom properties and mixins are available for styling:
 
       _fetchData: function (term, isProgramaticFetch) {
         var self = this;
-        var url = (self.customUrl || '/service/tree/tree-data/authorities/') + this.standardType + '?term=' + encodeURIComponent(term) + '&locale=' + this.langOverride || this.lang;
+        var url = (self.customUrl || '/service/tree/tree-data/authorities/') + this.standardType + '?term=' + encodeURIComponent(term) + '&locale=' + (this.langOverride || this.lang);
         this._req('GET', url).then(function (data) {
           self._handleResponse(data, isProgramaticFetch);
         }).catch(function (err) {

--- a/birch-standards-picker.html
+++ b/birch-standards-picker.html
@@ -624,6 +624,16 @@ The following custom properties and mixins are available for styling:
           reflectToAttribute: true,
           type: Boolean,
           value: false
+        },
+
+        /**
+         * Override the language of the data lookup in the date and place api. 
+         * If set to 'es' and the browser lang is set to 'en', the data entered would be Spanish.
+         * This is useful when we have records that have a different language than the
+         * browser language 
+         */
+        langOverride: {
+          type: String
         }
       },
 
@@ -771,7 +781,7 @@ The following custom properties and mixins are available for styling:
 
       _fetchData: function (term, isProgramaticFetch) {
         var self = this;
-        var url = (self.customUrl || '/service/tree/tree-data/authorities/') + this.standardType + '?term=' + encodeURIComponent(term) + '&locale=' + this.lang;
+        var url = (self.customUrl || '/service/tree/tree-data/authorities/') + this.standardType + '?term=' + encodeURIComponent(term) + '&locale=' + this.langOverride || this.lang;
         this._req('GET', url).then(function (data) {
           self._handleResponse(data, isProgramaticFetch);
         }).catch(function (err) {

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "birch-standards-picker",
-  "version": "2.14.13",
+  "version": "2.14.14",
   "description": "A picker for the FamilySearch date/place standards",
   "main": [
     "birch-standards-picker.html",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "birch-standards-picker",
-  "version": "2.14.13",
+  "version": "2.14.14",
   "description": "Polymer-based web component for viewing the fan chart pedigree view.",
   "directories": {
     "test": "test"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "eslint-config-frontier": "github:fs-webdev/eslint-config-frontier",
     "eslint-config-tree": "github:fs-webdev/eslint-config-tree#semver:^1",
-    "fs-common-build-scripts": "github:fs-webdev/fs-common-build-scripts#semver:^1",
+    "fs-common-build-scripts": "github:fs-webdev/fs-common-build-scripts#semver:^2",
     "husky": "^2"
   },
   "husky": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "eslint-config-frontier": "github:fs-webdev/eslint-config-frontier",
     "eslint-config-tree": "github:fs-webdev/eslint-config-tree#semver:^1",
-    "fs-common-build-scripts": "github:fs-webdev/fs-common-build-scripts#semver:^2",
+    "fs-common-build-scripts": "github:fs-webdev/fs-common-build-scripts#semver:^1",
     "husky": "^2"
   },
   "husky": {


### PR DESCRIPTION
We need a way to get back dates and places in a different language than what the browser has.  We have record data in say German and we want the patron to enter the date or place in the language of the record instead of the browser language setting.


