### PR TITLE
feature: add scrollIntoViewIfNeededOnListOpen

### DIFF
--- a/birch-standards-picker.html
+++ b/birch-standards-picker.html
@@ -308,6 +308,7 @@ The following custom properties and mixins are available for styling:
       value="{{searchTerm::birch-typeahead:input}}"
       placeholder="[[_getPlaceholder(standardType, i18n, disabled)]]"
       options="[[_typeaheadOptions]]"
+      on-birch-typeahead:list-opened='_handleListOpened'
       on-birch-typeahead:input='_handleInput'
       on-birch-typeahead:cancel='_handleCancel'
       on-birch-typeahead:blur='_handleCancel'
@@ -490,6 +491,11 @@ The following custom properties and mixins are available for styling:
         standardType: {
           type: String,
           value: 'date'
+        },
+
+        scrollIntoViewIfNeededOnListOpen: {
+          type: Boolean,
+          value: false
         },
 
         /**
@@ -777,6 +783,34 @@ The following custom properties and mixins are available for styling:
         if (!e.detail.value.trim()) return;
         this.loading = true;
         this._fetchData(e.detail.value, isProgramaticFetch);
+      },
+
+      _handleListOpened: function (evt) {
+        if (this.scrollIntoViewIfNeededOnListOpen) {
+          // scroll into view if needed
+          // this has to be inside a set timeout so that the list will actually render being opened before we scroll into view
+          setTimeout(() => {
+            if (!this.$.typeahead) {
+              return;
+            }
+            let typeahead = this.$.typeahead;
+            let offsetParent = typeahead.offsetParent;
+            let offsetParentIsScrollable = (offsetParent.scrollHeight > offsetParent.clientHeight) && (window.getComputedStyle(offsetParent).overflowY !== 'hidden');
+
+            if (!offsetParentIsScrollable) {
+              return;
+            }
+
+            let bottomOfTypeahead = typeahead.offsetTop + typeahead.scrollHeight;
+            let lastVisiblePixelInParent = offsetParent.scrollTop + offsetParent.clientHeight;
+
+            if (bottomOfTypeahead > lastVisiblePixelInParent) {
+              // scrolling is needed, so let's scroll :)
+              let scrollAmount = bottomOfTypeahead - lastVisiblePixelInParent;
+              offsetParent.scrollBy({top: scrollAmount, behavior: 'smooth'});
+            }
+          }, 0);
+        }
       },
 
       _fetchData: function (term, isProgramaticFetch) {

--- a/birch-standards-picker.html
+++ b/birch-standards-picker.html
@@ -801,12 +801,17 @@ The following custom properties and mixins are available for styling:
               return;
             }
 
+            // we use the scrollHeight here because the typeahead menu is technically outside the typeahead's height because typeahead has overflow:hidden
             let bottomOfTypeahead = typeahead.offsetTop + typeahead.scrollHeight;
             let lastVisiblePixelInParent = offsetParent.scrollTop + offsetParent.clientHeight;
 
             if (bottomOfTypeahead > lastVisiblePixelInParent) {
               // scrolling is needed, so let's scroll :)
               let scrollAmount = bottomOfTypeahead - lastVisiblePixelInParent;
+              if (typeahead.scrollHeight > offsetParent.clientHeight) {
+                // only scroll to the input top since the screen is shorter than the height of the typeahead.
+                scrollAmount = typeahead.offsetTop - offsetParent.scrollTop;
+              }
               offsetParent.scrollBy({top: scrollAmount, behavior: 'smooth'});
             }
           }, 0);

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "birch-standards-picker",
-  "version": "2.14.15",
+  "version": "2.15.0",
   "description": "A picker for the FamilySearch date/place standards",
   "main": [
     "birch-standards-picker.html",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "birch-standards-picker",
-  "version": "2.14.15",
+  "version": "2.15.0",
   "description": "Polymer-based web component for viewing the fan chart pedigree view.",
   "directories": {
     "test": "test"

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -41,9 +41,9 @@
       "thresholds": {
         "global": {
           "statements": 65,
-          "branches": 60,
-          "functions": 85,
-          "lines": 70
+          "branches": 55,
+          "functions": 80,
+          "lines": 65
         }
       }
     },


### PR DESCRIPTION
* if the standards picker menu isn't visible when it displays, this gives the consumer the option to scroll it into view

depends on: https://github.com/fs-webdev/birch-typeahead/pull/28 to work.

chrome:
![chrome-scrolling](https://user-images.githubusercontent.com/11645238/84824526-16557d00-afee-11ea-9036-c64de4b2ff80.gif)
safari:
![safari-scrolling](https://user-images.githubusercontent.com/11645238/84824531-18b7d700-afee-11ea-9054-63210b64717f.gif)
firefox:
![firefox-scrolling](https://user-images.githubusercontent.com/11645238/84824512-12295f80-afee-11ea-90c5-afefa8575df1.gif)

Note: Jeff is cool with the jumpy behavior in firefox
